### PR TITLE
LevelBuilder bugfix

### DIFF
--- a/MadScienceLab/MadScienceLab/LevelBuilder.cs
+++ b/MadScienceLab/MadScienceLab/LevelBuilder.cs
@@ -77,7 +77,7 @@ namespace MadScienceLab
 
             String newline = "\r\n"; //in case a newline were to be used
             levelheight = leveltxt.Length - leveltxt.Replace ("\n", "" ).Length;
-            
+            levelwidth = 0; //reset this each time a new level is made
             
             //there will be walls and floor enclosing the aforementioned level
             //iterate through level string, find the level height and width from iterating through the txt file

--- a/MadScienceLab/MadScienceLab/Levels/level1.txt
+++ b/MadScienceLab/MadScienceLab/Levels/level1.txt
@@ -4,7 +4,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                       @X
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX2XX                   XXXXXX
 X        X                X          XXXXX M        MXXXXXX
 X        X       X        X          XXXXXB          XXXXXX
-X  P   T D   B   X    S B D  t      BXXXXXBB         XXXXXX 
+X  P   T D   B   X    S B D  t      BXXXXXBB         XXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Above is level, below are links.


### PR DESCRIPTION
Made it reset the level width each time a new level is made (ie. MakeBasicLevel(int levelNum) is called) now. This avoids the levelwidth from preserving the width of the previous level.

Also fixed a level that had an empty space in the txt file.